### PR TITLE
Enhance travis

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,18 +2,21 @@
 
 To contribute, please follow this process:
 
-Fork this repository: https://github.com/emma-sax4/zoesax301.github.io/fork
+1. Fork this repository: https://github.com/emma-sax4/zoesax301.github.io/fork
+2. Make your changes on a feature branch:
 
-| With GitHub UI | On your computer with Git |
-|----------------|---------------------------|
-| Make your first change | Make sure you have this repository cloned to your machine and then create your feature branch:<br>`git checkout -b my-new-feature-branch` |
-| When you're ready to commit your first change, make a new branch and name it appropriately | Make your first few changes |
-| Click that green `Commit changes` button | Commit and push your changes:<br>`git commit -am "Add some feature" && git push` |
-| Make a new pull request for your new branch (GitHub UI might automatically direct you to do this) | Continue making changes and committing/pushing them (unless you leave your feature branch, all new commits will be automatically added to your branch) |
-| Continue making changes to your pull request/branch (navigate to the main repository page, switch to your feature branch, and then continue making whatever changes you'd like) | When you're satisfied, make a pull request to this repository in the UI |
+  | With GitHub UI | On your computer with Git |
+  |----------------|---------------------------|
+  | Make your first change. | Make sure you have this repository cloned to your machine and then create your feature branch. <br>`git checkout -b my-new-feature-branch` |
+  | When you're ready to commit your first change, make a new branch and name it appropriately. | Make your first few changes. |
+  | Click that green `Commit changes` button. | Commit and push your changes.<br>`git commit -am "Add some feature" && git push` |
+  | Make a new pull request for your new branch (GitHub UI should automatically direct you to do this). | Continue making changes and committing/pushing them (unless you leave your feature branch, all new commits will be automatically added to your branch). |
+  | Continue making changes to your pull request/branch (navigate to the main repository page, switch to your feature branch, and then continue making whatever changes you'd like). | When you're satisfied, make a pull request to this repository in the GitHub UI. |
 
-To see what your changes look like, follow the instructions in the [Running Locally](https://github.com/emma-sax4/zoesax301.github.io/blob/master/README.md#running-locally) section of the README. If you've been working on GitHub directly up until this point, you may need to switch over to a computer and clone the repository and branch to do this.
+3. Verify TravisCI passes on your pull request. The test configuration lives inside the [`.travis.yml`](https://github.com/emma-sax4/zoesax301.github.io/blob/master/.travis.yml) file. Read more about this repository's tests [here](https://github.com/emma-sax4/zoesax301.github.io#running-tests).
+4. Check the site looks like how you expect it to look. Follow the instructions [here](https://github.com/emma-sax4/zoesax301.github.io#running-locally) to get your computer running the site locally. If you've been working on GitHub UI up until this point, you may need to switch over to a computer and clone the repository and branch to do this.
+5. When you're absolutely ready for me to look at your pull request, please request a Code Review from me in the pull request.
 
-When you're absolutely ready for me to look at your pull request, please request a Code Review from me in the pull request.
+If I don't comment or start looking at the pull request in a few days, feel free to [send me an email](mailto:emma.sax4@gmail.com).
 
-If I don't comment or start looking at the pull request in a couple of days, feel free to [send me an email](mailto:emma.sax4@gmail.com).
+Happy coding! 🤗

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,5 @@
 * Pull Request #1
 * Pull Request #2
 
-## Additional context
+## Additional Context
 > Add any other context about the problem here.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 sudo: false
 language: ruby
 cache: bundler
+
 branches:
   only:
     - master
-script: true
+
+notifications:
+  email:
+    on_success: never
+    on_failure: always
+    on_error: always
+
+script: JEKYLL_ENV=production bundle exec jekyll build

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 For more information on contributing to this project, please see [CONTRIBUTING.md](https://github.com/emma-sax4/zoesax301.github.io/blob/master/.github/CONTRIBUTING.md).
 
-To submit a feature request or a bug ticket, please use submit an official [GitHub Issue](https://github.com/emma-sax4/zoesax301.github.io/issues/new/choose).
+To submit a feature request or a bug ticket, please submit an official [GitHub Issue](https://github.com/emma-sax4/zoesax301.github.io/issues/new/choose).
 
 For information on licensing, please see [LICENSE](https://github.com/emma-sax4/zoesax301.github.io/blob/master/LICENSE).
 
@@ -39,7 +39,7 @@ NOTE: Running this process locally will most likely create at least one director
 
 ## Running Tests
 
-This repository doesn't really have any tests at all (GitHub Pages is just a host of static site files, so there's no functionality to test). I do run TravisCI tests on every pull request and commit to master branch, but, as you can see from the [`.travis.yml`](https://github.com/emma-sax4/zoesax301.github.io/blob/master/.travis.yml), all the Travis run does is run `script: true`, so the builds will always pass (assuming `bundle` can properly install the dependencies as well).
+This repository doesn't really have any tests at all (GitHub Pages is just a host of static site files, so there's no functionality to test). However, I do like to check that `bundle` can install the necessary dependencies and that Jekyll can properly build the site on each pull request and commit to `master` branch.
 
 ## Deployments
 

--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,4 @@ include:
 exclude:
   - Gemfile
   - Gemfile.lock
-
-relative_links:
-  enabled: true
-  collections: true
+  - vendor/

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,6 +2,7 @@
   &copy; <script>
     new Date().getFullYear()>2010&&document.write(" "+new Date().getFullYear());
   </script> by
-  <a href="{{ site.github.owner }}" target="_blank">Emma Sax</a>. All rights reserved. Powered by
-  <a href="https://pages.github.com" target="_blank">GitHub Pages</a>.
+  <a href="{{ site.github.owner }}" target="_blank">Emma Sax</a>.
+  All rights reserved. View <a href="{{ site.github.repo }}" target="_blank">source code</a>.
+  Powered by <a href="https://pages.github.com" target="_blank">GitHub Pages</a>.
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,8 +1,7 @@
 <footer class="footer">
-  &copy; <script>
-    new Date().getFullYear()>2010&&document.write(" "+new Date().getFullYear());
-  </script> by
-  <a href="{{ site.github.owner }}" target="_blank">Emma Sax</a>.
-  All rights reserved. View <a href="{{ site.github.repo }}" target="_blank">source code</a>.
+  &copy; <script>new Date().getFullYear()>2010&&document.write(" "+new Date().getFullYear());</script> by
+    <a href="{{ site.github.owner }}" target="_blank">Emma Sax</a>.
+  All rights reserved.
+  View <a href="{{ site.github.repo }}" target="_blank">source code</a>.
   Powered by <a href="https://pages.github.com" target="_blank">GitHub Pages</a>.
 </footer>


### PR DESCRIPTION
## Changes
* Email committer when a Travis build fails or errors
* Run `jekyll build` in Travis
* Update the README's section on tests
* Add a link to the source code from the footer
* Move around the code in the footer
* Update CONTRIBUTING.md

## Additional Context
Also added `exclude: [vendor]` based on the suggestions here (https://github.com/jekyll/jekyll/issues/2938), otherwise the Travis won't successfully build because apparently Jekyll has some example blog posts that won't sit nicely with `jekyll build` 🤷🏻‍♀️